### PR TITLE
Add state machine skeleton

### DIFF
--- a/app/src/main/java/org/aquapackrobotics/sw8s/App.java
+++ b/app/src/main/java/org/aquapackrobotics/sw8s/App.java
@@ -3,12 +3,23 @@
  */
 package org.aquapackrobotics.sw8s;
 
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import org.aquapackrobotics.sw8s.missions.Mission;
+import org.aquapackrobotics.sw8s.missions.AutoMission;
+
 public class App {
+
+    static final int POOLSIZE = 1;
+
     public String getGreeting() {
         return "Hello World!";
     }
 
     public static void main(String[] args) {
-        System.out.println(new App().getGreeting());
+        ScheduledThreadPoolExecutor pool = new ScheduledThreadPoolExecutor(POOLSIZE);
+        Mission mission = (Mission) new AutoMission(pool);
+
+        mission.run();
     }
 }

--- a/app/src/main/java/org/aquapackrobotics/sw8s/missions/AutoMission.java
+++ b/app/src/main/java/org/aquapackrobotics/sw8s/missions/AutoMission.java
@@ -1,0 +1,32 @@
+package org.aquapackrobotics.sw8s.missions;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import org.aquapackrobotics.sw8s.missions.Mission;
+
+/**
+ * Competition mission, fully autonomous.
+ */
+public class AutoMission extends Mission {
+
+    public AutoMission(ScheduledThreadPoolExecutor pool) {
+        super(pool);
+    }
+
+    // TODO: implement
+    @Override
+    protected Object initialState() {
+        return null;
+    }
+
+    // TODO: implement
+    @Override
+    protected void executeState(Object state) {
+    }
+
+    // TODO: implement
+    @Override
+    protected Object nextState(Object state) {
+        return null;
+    }
+}

--- a/app/src/main/java/org/aquapackrobotics/sw8s/missions/AutoMission.java
+++ b/app/src/main/java/org/aquapackrobotics/sw8s/missions/AutoMission.java
@@ -2,7 +2,7 @@ package org.aquapackrobotics.sw8s.missions;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
-import org.aquapackrobotics.sw8s.missions.Mission;
+import org.aquapackrobotics.sw8s.states.State;
 
 /**
  * Competition mission, fully autonomous.
@@ -15,18 +15,18 @@ public class AutoMission extends Mission {
 
     // TODO: implement
     @Override
-    protected Object initialState() {
+    protected State initialState() {
         return null;
     }
 
     // TODO: implement
     @Override
-    protected void executeState(Object state) {
+    protected void executeState(State state) {
     }
 
     // TODO: implement
     @Override
-    protected Object nextState(Object state) {
+    protected State nextState(State state) {
         return null;
     }
 }

--- a/app/src/main/java/org/aquapackrobotics/sw8s/missions/Mission.java
+++ b/app/src/main/java/org/aquapackrobotics/sw8s/missions/Mission.java
@@ -32,7 +32,7 @@ public abstract class Mission {
      * <p>
      * Proceeds through all states in graph.
      */
-    void run() {
+    public void run() {
         Object currentState = initialState();
         while (currentState != null) {
             executeState(currentState);
@@ -43,7 +43,7 @@ public abstract class Mission {
     /**
      * Returns the machine's starting state.
      */
-    abstract Object initialState();
+    protected abstract Object initialState();
 
     /**
      * Wraps running the code in a state.
@@ -52,7 +52,7 @@ public abstract class Mission {
      *
      * @param state current machine state
      */
-    abstract void executeState(Object state);
+    protected abstract void executeState(Object state);
 
     /**
      * Computes the next machine state.
@@ -61,5 +61,5 @@ public abstract class Mission {
      *
      * @param state current machine state
      */
-    abstract Object nextState(Object state);
+    protected abstract Object nextState(Object state);
 }

--- a/app/src/main/java/org/aquapackrobotics/sw8s/missions/Mission.java
+++ b/app/src/main/java/org/aquapackrobotics/sw8s/missions/Mission.java
@@ -22,6 +22,8 @@ public abstract class Mission {
      * <p>
      * Extension isn't expected.
      * Guarantees all Mission objects use a thread pool.
+     *
+     * @param pool A non-filled thread pool
      */
     public Mission(ScheduledThreadPoolExecutor pool) {
         this.pool = pool;

--- a/app/src/main/java/org/aquapackrobotics/sw8s/missions/Mission.java
+++ b/app/src/main/java/org/aquapackrobotics/sw8s/missions/Mission.java
@@ -2,6 +2,8 @@ package org.aquapackrobotics.sw8s.missions;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
+import org.aquapackrobotics.sw8s.states.State;
+
 /**
  * Robot behavior interface.
  * <p>
@@ -35,7 +37,7 @@ public abstract class Mission {
      * Proceeds through all states in graph.
      */
     public void run() {
-        Object currentState = initialState();
+        State currentState = initialState();
         while (currentState != null) {
             executeState(currentState);
             currentState = nextState(currentState);
@@ -45,7 +47,7 @@ public abstract class Mission {
     /**
      * Returns the machine's starting state.
      */
-    protected abstract Object initialState();
+    protected abstract State initialState();
 
     /**
      * Wraps running the code in a state.
@@ -54,7 +56,7 @@ public abstract class Mission {
      *
      * @param state current machine state
      */
-    protected abstract void executeState(Object state);
+    protected abstract void executeState(State state);
 
     /**
      * Computes the next machine state.
@@ -63,5 +65,5 @@ public abstract class Mission {
      *
      * @param state current machine state
      */
-    protected abstract Object nextState(Object state);
+    protected abstract State nextState(State state);
 }

--- a/app/src/main/java/org/aquapackrobotics/sw8s/missions/Mission.java
+++ b/app/src/main/java/org/aquapackrobotics/sw8s/missions/Mission.java
@@ -1,0 +1,65 @@
+package org.aquapackrobotics.sw8s.missions;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+/**
+ * Robot behavior interface.
+ * <p>
+ * Missions are state machines, using State objects to progress.
+ */
+public abstract class Mission {
+    /**
+     * Processing thread pool.
+     * <p>
+     * Repeated tasks are Runnables, submitted with FixedRate.
+     * <p>
+     * Single tasks with a return value are Callables, submitted with schedule
+     */
+    protected ScheduledThreadPoolExecutor pool;
+
+    /**
+     * Generic Mission constructor.
+     * <p>
+     * Extension isn't expected.
+     * Guarantees all Mission objects use a thread pool.
+     */
+    public Mission(ScheduledThreadPoolExecutor pool) {
+        this.pool = pool;
+    }
+
+    /**
+     * Execute the state machine.
+     * <p>
+     * Proceeds through all states in graph.
+     */
+    void run() {
+        Object currentState = initialState();
+        while (currentState != null) {
+            executeState(currentState);
+            currentState = nextState(currentState);
+        }
+    }
+
+    /**
+     * Returns the machine's starting state.
+     */
+    abstract Object initialState();
+
+    /**
+     * Wraps running the code in a state.
+     * <p>
+     * Wrapper is useful for non-state actions, i.e. checking operator input
+     *
+     * @param state current machine state
+     */
+    abstract void executeState(Object state);
+
+    /**
+     * Computes the next machine state.
+     * <p>
+     * Uses fields from the current state and Mission parameters.
+     *
+     * @param state current machine state
+     */
+    abstract Object nextState(Object state);
+}

--- a/app/src/main/java/org/aquapackrobotics/sw8s/states/InitState.java
+++ b/app/src/main/java/org/aquapackrobotics/sw8s/states/InitState.java
@@ -1,0 +1,27 @@
+package org.aquapackrobotics.sw8s.states;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+public class InitState extends State {
+    public InitState(ScheduledThreadPoolExecutor pool) {
+        super(pool);
+    }
+
+    // TODO: implement
+    public void onEnter() {
+    }
+
+    // TODO: implement
+    public boolean onPeriodic() {
+        return false;
+    }
+
+    // TODO: implement
+    public void onExit() {
+    }
+
+    // TODO: implement
+    public State nextState() {
+        return null;
+    }
+}

--- a/app/src/main/java/org/aquapackrobotics/sw8s/states/State.java
+++ b/app/src/main/java/org/aquapackrobotics/sw8s/states/State.java
@@ -1,4 +1,4 @@
-package org.aquapackrobotics.sw8s.missions;
+package org.aquapackrobotics.sw8s.states;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 

--- a/app/src/main/java/org/aquapackrobotics/sw8s/states/State.java
+++ b/app/src/main/java/org/aquapackrobotics/sw8s/states/State.java
@@ -1,0 +1,58 @@
+package org.aquapackrobotics.sw8s.missions;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+/**
+ * One step of machine execution.
+ * <p>
+ * Every separate task that is completed should be a different state.
+ * Each task has start conditions, execution logic, and end conditions
+ */
+public abstract class State {
+    protected ScheduledThreadPoolExecutor pool;
+
+    /**
+     * Creates a state instance.
+     * <p>
+     * Do not preserve State instances, create new ones when a task repeats.
+     *
+     * @param pool the Missions' pool for task submission
+     */
+    public State(ScheduledThreadPoolExecutor pool) {
+        this.pool = pool;
+    }
+
+    /**
+     * Enforce starting conditions.
+     */
+    abstract public void onEnter();
+
+    /**
+     * Repeatedly called by state machine.
+     * <p>
+     * Should not loop.
+     * Looping here can trap the state machine.
+     * Condition checking should be if, not while.
+     *
+     * @return if exit conditions are met
+     */
+    abstract public boolean onPeriodic();
+
+    /**
+     * Cleans up state effects and threads.
+     * <p>
+     * After onExit, the robot and thread pool state should be identical to
+     * before onEnter.
+     */
+    abstract public void onExit();
+
+    /**
+     * Recommends the next state.
+     * <p>
+     * May be ignored by a state machine override.
+     * Otherwise should be the main decision on the next state.
+     *
+     * @return an instance for the next state
+     */
+    abstract public State nextState();
+}


### PR DESCRIPTION
This merge defines the basic classes and main loop for state machine processing. Placeholder state and mission classes are included but not comprehensive of the final design. The thread pool is currently unused. Refer to the wiki for graphics detailing the state machine.